### PR TITLE
Remove ajv-keywords, add `is` keyword, add `addKeyword()` function, restructure `addTypes()` input args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "object-model",
+  "name": "@unplgtc/object-model",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -14,11 +14,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/unplgtc/ObjectModel#readme",
   "dependencies": {
-    "ajv": "^6.10.2",
-    "ajv-keywords": "^3.4.1"
+    "ajv": "^6.10.2"
   }
 }

--- a/src/services/ajvService.js
+++ b/src/services/ajvService.js
@@ -3,24 +3,86 @@
 const Ajv = require('ajv');
 const ajv = new Ajv({ verbose: true });
 
-// Add the `instanceof` keyword to our ajv instance
-require('ajv-keywords')(ajv, 'instanceof');
+const TYPES = {
+	Object: Object,
+	Array: Array,
+	Function: Function,
+	Number: Number,
+	String: String,
+	Date: Date,
+	RegExp: RegExp,
+	Buffer: Buffer,
+	Promise: Promise
+}
 
-const ajvInstanceof = require('ajv-keywords/keywords/instanceof').definition;
+const isKeyword = {
+	compile: function(schema) {
+		if (typeof schema === 'string') {
+			const type = getType(schema);
+			return function(data) {
+				try {
+					return type.isPrototypeOf(data) || data instanceof type;
+				} catch (err) {
+					// Not the prototype, and cannot call instanceof on this Object
+					return false;
+				}
+			}
+		} else {
+			const types = schema.map(getType);
+			return function(data) {
+				for (const type of types) {
+					try {
+						if (type.isPrototypeOf(data) || data instanceof type) {
+							return true;
+						}
+					} catch (err) {}
+				}
+				return false;
+			}
+		}
+	},
+
+	metaSchema: {
+		anyOf: [
+			{ type: 'string' },
+			{
+				type: 'array',
+				items: { type: 'string' }
+			}
+		]
+	}
+}
+
+function getType(type) {
+	if (TYPES[type]) {
+		return TYPES[type];
+	}
+	throw new Error(`Invalid 'is' keyword type '${type}'`);
+}
+
+ajv.addKeyword('is', isKeyword);
 
 const ajvService = {
 	get ajv() {
 		return ajv;
 	},
 
+	addKeyword(keyword, validator) {
+		ajv.addKeyword(keyword, validator);
+	},
+
 	addTypes(types) {
-		for (const nameAndType of types) {
-			this.addType(...nameAndType);
+		for (const [name, type] of Object.entries(types)) {
+			this.addType(name, type);
 		}
 	},
 
 	addType(name, type) {
-		ajvInstanceof.CONSTRUCTORS[name] = type;
+		if (!TYPES[name]) {
+			TYPES[name] = type;
+		} else {
+			throw new Error(`Type '${name}' already added to AJV`);
+		}
 	}
 }
 


### PR DESCRIPTION
- Remove ajv-keywords dep, which also removes the built-in `instanceof` keyword
- Add built-in `is` keyword which checks both `isPrototypeOf` and `instanceof`
- Add new `addKeyword()` function which will let users extend AJV with custom keywords
- Restructure expected argument format for `addTypes()` function to take an Object instead of an Array