### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/object-model",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Fluent AJV object model validator for Node applications",
   "main": "src/ObjectModel.js",
   "scripts": {


### PR DESCRIPTION
Changelog:
- Remove `ajv-keywords` dep, which also removes the built-in `instanceof` keyword
- Add built-in `is` keyword which checks both `isPrototypeOf` and `instanceof`
- Add new `addKeyword()` function which will let users extend AJV with custom keywords
- Restructure expected argument format for `addTypes()` function to take an Object instead of an Array