### PR TITLE
'schemata' -> 'schemas', ValidationError improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ObjectModel
     .validate(user)
 ```
 
-## Adding new Schemata
+## Adding new Schemas
 
 - Create a new JS file for your schema (Example: `UserSchema.js` for a 'User' schema)
 - In your schema file:
@@ -70,7 +70,7 @@ const UserSchema = {
 module.exports = UserSchema;
 ```
 
-## Upgrading Schemata
+## Upgrading Schemas
 
 If you make changes to a domain object then its schema needs to be updated, but making that update at the same time across all of your code bases isn't always feasible. ObjectModel allows you to add a new version function to your schema file, then you can selectively validate with the new version where you need to while older code continues using the older version. In the example above, just add a `v2()` function and then validate against it using the following:
 
@@ -156,23 +156,23 @@ ObjectModel.addTypes(types);
 
 The above steps are all you need to use this package, but we've found the below architecture a nice way to include some common attributes across all schema that you build.
 
-Package your schemata in a `/schemata` (or similarly named) directory, or at least package `index.js` and `common.js` files in such a directory. `/schemata/index.js` should export an Object whose keys are your schema keys and whose values are your schema Objects. `/schemata/common.js` should export an Object which contains functions to generate schemata with common values (such as the JSON Schema draft version that you're using) and validate schemata using `ObjectModel`'s validator function.
+Package your schemas in a `/schemas` (or similarly named) directory, or at least package `index.js` and `common.js` files in such a directory. `/schemas/index.js` should export an Object whose keys are your schema keys and whose values are your schema Objects. `/schemas/common.js` should export an Object which contains functions to generate schemas with common values (such as the JSON Schema draft version that you're using) and validate schemas using `ObjectModel`'s validator function.
 
-Example `/schemata/index.js` file:
+Example `/schemas/index.js` file:
 
 ```js
 'use strict';
 
 const UserSchema = require('./UserSchema');
 
-const schemata = {
+const schemas = {
     [UserSchema.key]: UserSchema
 }
 
-module.exports = schemata;
+module.exports = schemas;
 ```
 
-Example `/schemata/common.js` file:
+Example `/schemas/common.js` file:
 
 ```js
 'use strict';
@@ -187,7 +187,7 @@ const common = {
     v1(schemaTitle) {
         return {
             '$schema': 'http://json-schema.org/draft-07/schema#',
-            '$id': `https://github.com/username/repo/blob/master/src/schemata/${schemaTitle}Schema.js`
+            '$id': `https://github.com/username/repo/blob/master/src/schemas/${schemaTitle}Schema.js`
         }
     }
 }
@@ -195,7 +195,7 @@ const common = {
 module.exports = common;
 ```
 
-Example `/schemata/UserSchema.js` file which uses `common.js`:
+Example `/schemas/UserSchema.js` file which uses `common.js`:
 
 ```js
 const common = require('./common');
@@ -238,10 +238,10 @@ Validate using the above architecture in essentially the same way as before:
 ```js
 const ObjectModel = require('@unplgtc/object-model'),
       SCHEMA = ObjectModel.SCHEMA,
-      schemata = require('./path/to/schemata')
+      schemas = require('./path/to/schemas')
       userService = require('./path/to/userService');
 
-ObjectModel.addSchemata(schemata);
+ObjectModel.addSchemas(schemas);
 
 const user = await userService.get('<user_identifier>');
 
@@ -251,4 +251,4 @@ ObjectModel
     .validate(user)
 ```
 
-That example only used one schema, but the main advantage of the above architecture is that you can implement many different schema files, include common values in all of them, and import them all into your ObjectModel instance at once via the `index.js` file. In time if you need to upgrade to a newer version of the JSON Schema standard, just add a `v2()` function to your `common` Object and slowly upgrade individual schemata by adjusting them to pass `common.v2` to the validator instead of `common.v1`.
+That example only used one schema, but the main advantage of the above architecture is that you can implement many different schema files, include common values in all of them, and import them all into your ObjectModel instance at once via the `index.js` file. In time if you need to upgrade to a newer version of the JSON Schema standard, just add a `v2()` function to your `common` Object and slowly upgrade individual schemas by adjusting them to pass `common.v2` to the validator instead of `common.v1`.

--- a/src/ObjectModel.js
+++ b/src/ObjectModel.js
@@ -5,7 +5,7 @@ const enumerate = require('./utilities').enumerate,
 
 const ObjectModel = {
     get SCHEMA() {
-    	return enumerate(schemaService.schemata)
+    	return enumerate(schemaService.schemas)
     },
 
     ERRORS: errors,

--- a/src/errors/ValidationError.js
+++ b/src/errors/ValidationError.js
@@ -28,7 +28,7 @@ class ValidationError extends Error {
 		}
 
 		if (ajvErrors) {
-			this.message += ` at \`${ajvErrors.dataPath}\``;
+			this.message += ` at ${ajvErrors.dataPath || 'top-level'}`;
 
 			Object.defineProperty(this, 'failedProperty', {
 				value: ajvErrors.keyword,
@@ -39,6 +39,13 @@ class ValidationError extends Error {
 
 			Object.defineProperty(this, 'failedPropertyPath', {
 				value: ajvErrors.dataPath,
+				writable: false,
+				configurable: false,
+				enumerable: false
+			});
+
+			Object.defineProperty(this, 'schema', {
+				value: ajvErrors.schema,
 				writable: false,
 				configurable: false,
 				enumerable: false
@@ -58,13 +65,59 @@ class ValidationError extends Error {
 				enumerable: false
 			});
 
+			Object.defineProperty(this, 'params', {
+				value: ajvErrors.params,
+				writable: false,
+				configurable: false,
+				enumerable: false
+			});
+
 			Object.defineProperty(this, 'data', {
 				value: ajvErrors.data,
 				writable: false,
 				configurable: false,
 				enumerable: false
 			});
+
+			switch (ajvErrors.keyword) {
+				case 'additionalProperties':
+					return this.additionalPropertiesError();
+				case 'is':
+					return this.isError();
+				case 'minProperties':
+					console.log(ajvErrors)
+					return this.minPropertiesError();
+				case 'type':
+					return this.typeError();
+			}
 		}
+	}
+
+	additionalPropertiesError() {
+		this.message += ` but found \`${this.params.additionalProperty}\``;
+	}
+
+	isError() {
+		let type = typeof this.data;
+
+		if (type === 'object') {
+			type = this.data.constructor.name;
+		}
+
+		this.message += ` (required type in [${this.schema}] but got \`${type}\`)`
+	}
+
+	minPropertiesError() {
+		const missingProps = JSON.stringify(
+			Object.keys(this.parentSchema.properties)
+				.filter(it => !Object.keys(this.data).includes(it))
+		);
+
+		this.message += ` but found only ${Object.keys(this.data).length} properties (missing ${missingProps})`;
+	}
+
+	typeError() {
+		this.message += ` but found ${typeof this.data}`;
 	}
 }
 

--- a/src/services/schemaService.js
+++ b/src/services/schemaService.js
@@ -3,37 +3,37 @@
 const ajvService = require('./ajvService'),
       UniqueKeyException = require('../errors/UniqueKeyException');
 
-const schemata = {};
+const schemas = {};
 
 const schemaService = {
-	get schemata() {
-		return schemata;
+	get schemas() {
+		return schemas;
 	},
 
 	schema(id) {
-		return schemata[id];
+		return schemas[id];
 	},
 
-	addSchemata(newSchemata) {
-		for (const key of Object.keys(newSchemata)) {
-			if (schemata[key]) {
+	addSchemas(newSchemas) {
+		for (const key of Object.keys(newSchemas)) {
+			if (schemas[key]) {
 				throw new UniqueKeyException(
 					`Schema key '${key}' already exists on this ObjectModel`,
 					key
 				);
 			}
-			schemata[key] = newSchemata[key];
+			schemas[key] = newSchemas[key];
 		}
 	},
 
 	addSchema(key, newSchema) {
-		if (schemata[key]) {
+		if (schemas[key]) {
 			throw new UniqueKeyException(
 				`Schema key '${key}' already exists on this ObjectModel`,
 				key
 			);
 		}
-		schemata[key] = newSchema;
+		schemas[key] = newSchema;
 	}
 }
 


### PR DESCRIPTION
- Changed 'schemata' to 'schemas' for our schema plurals
- Added more data onto ValidationError objects
- Improved ValidationError messages to include more relevant data for specific error keywords
   - Newly covered keywords:
      - additionalProperties
      - is
      - minProperties
      - type